### PR TITLE
Make exams reference user_courses

### DIFF
--- a/db/migrate/20200104114116_change_exams_ref_to_user_courses.rb
+++ b/db/migrate/20200104114116_change_exams_ref_to_user_courses.rb
@@ -1,0 +1,7 @@
+class ChangeExamsRefToUserCourses < ActiveRecord::Migration[6.0]
+  def change
+    remove_reference :exams, :user
+    remove_reference :exams, :course
+    add_reference :exams, :user_course, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_01_231817) do
+ActiveRecord::Schema.define(version: 2020_01_04_114116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,15 +39,13 @@ ActiveRecord::Schema.define(version: 2020_01_01_231817) do
   end
 
   create_table "exams", force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "course_id"
     t.integer "status", default: 0
     t.datetime "expiration_date"
     t.integer "attempts", default: 0
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["course_id"], name: "index_exams_on_course_id"
-    t.index ["user_id"], name: "index_exams_on_user_id"
+    t.bigint "user_course_id"
+    t.index ["user_course_id"], name: "index_exams_on_user_course_id"
   end
 
   create_table "institutes", force: :cascade do |t|


### PR DESCRIPTION
Before, the exams model referenced both :user and :course. We already have a model that represents that union called :user_course.