### PR TITLE
Add DeleteModal

### DIFF
--- a/src/components/UserCourse.vue
+++ b/src/components/UserCourse.vue
@@ -6,7 +6,7 @@
           {{ userCourse.course.name }}
         </p>
         <p class="font-weight-light m-0">
-          {{ userCourse.course.institute }}
+          {{ userCourse.course.institute.name }}
         </p>
       </b-col>
       <b-col cols="6" class="m-0 text-truncate">
@@ -24,6 +24,30 @@
     </b-row>
   </li>
 </template>
+
+<script>
+import EventBus from '@/eventBus';
+
+export default {
+  name: 'UserCourse',
+  props: {
+    userCourse: Object,
+  },
+  methods: {
+    toggleDelete() {
+      const deleteCall = {
+        id: this.userCourse.id,
+        type: 'UserCourse',
+      };
+      EventBus.$emit('delete-requested', deleteCall);
+      EventBus.$on('delete-done', (deleteChannel) => {
+        this.$emit(deleteChannel, this.userCourse.id);
+        EventBus.$off('delete-done');
+      });
+    },
+  },
+};
+</script>
 
 <style scoped>
 .vertical-center {
@@ -59,24 +83,3 @@
   color: #721c24;
 }
 </style>
-
-<script>
-export default {
-  name: 'Course',
-  props: {
-    userCourse: Object,
-  },
-  
-  data() {
-    return {
-      delete: false,
-    };
-  },
-
-  methods: {
-    toggleDelete() {
-      this.delete = !this.delete;
-    },
-  },
-};
-</script>

--- a/src/components/modals/DeleteModal.vue
+++ b/src/components/modals/DeleteModal.vue
@@ -1,0 +1,37 @@
+<template>
+  <b-modal id="delete-confirmation" hide-footer title="Estas seguro?">
+    <b-button variant="danger" class="mr-1" @click="callDelete">Eliminar</b-button>
+    <b-button variant="secondary" @click="cancelAction">Cancelar</b-button>
+  </b-modal>
+</template>
+
+<script>
+import EventBus from '@/eventBus';
+
+export default {
+  name: 'DeleteModal',
+  data() {
+    return {
+      requestedObject: Object,
+    };
+  },
+  created() {
+    EventBus.$on('delete-requested', (deleteCall) => {
+      this.requestedObject = deleteCall;
+      this.$bvModal.show('delete-confirmation');
+    });
+  },
+  methods: {
+    callDelete() {
+      const functionName = `delete${this.requestedObject.type}`;
+      window[functionName](this.requestedObject.id);
+      this.$bvModal.hide('delete-confirmation');
+      EventBus.$emit('delete-done', 'deleted');
+    },
+    cancelAction() {
+      this.$bvModal.hide('delete-confirmation');
+      EventBus.$emit('delete-done', 'canceled');
+    },
+  },
+};
+</script>

--- a/src/eventBus.js
+++ b/src/eventBus.js
@@ -1,0 +1,4 @@
+import Vue from 'vue';
+
+const EventBus = new Vue();
+export { EventBus as default };

--- a/src/services/userCourseService.js
+++ b/src/services/userCourseService.js
@@ -4,6 +4,10 @@ import API_URL from '../constants';
 
 const USER_COURSES_URL = `${API_URL}/user_courses`;
 
+window.deleteUserCourse = function (userCourseId) {
+  return axios.delete(`${USER_COURSES_URL}/${userCourseId}`);
+};
+
 export default {
   index() {
     return axios.get(USER_COURSES_URL);


### PR DESCRIPTION
### **What I did**
Created a Modal that handles all delete confirmations.

### **How I did it**
Created an Event Bus. Every time an event through the channel `delete-requested` is emitted, the modal grabs it, takes the id and the object type sended though the channel, does the deletion and sends a confirmation. 

It is imported to note that the delete method of every service needs to be public. 

Also there needs to be a naming convention for such methods and object types. 